### PR TITLE
remove world reset

### DIFF
--- a/isaac_ws/go1_standalone.py
+++ b/isaac_ws/go1_standalone.py
@@ -88,7 +88,6 @@ class Go1Runner(object):
                     way_points=way_points,
                     use_ros=True))
 
-        self._world.reset()
         self._enter_toggled = 0
         self._base_command = [0.0, 0.0, 0.0, 0]
         self._event_flag = False


### PR DESCRIPTION
Go1Runner의 생성자에서 world를 reset할 경우 오류가 발생하네요.  
@mqjinwon 님 환경에서는 잘 작동하는거죠? 이 라인을 지우고도 잘 동작하는지 봐주실 수 있을까요?  

```
Traceback (most recent call last):
  File "./QNAI/isaac_ws/go1_standalone.py", line 251, in <module>
    main()
  File "./QNAI/isaac_ws/go1_standalone.py", line 239, in main
    way_points=None)
  File "./QNAI/isaac_ws/go1_standalone.py", line 91, in __init__
    self._world.reset()
  File "/home/nicky/.local/share/ov/pkg/isaac_sim-2022.2.1/exts/omni.isaac.core/omni/isaac/core/world/world.py", line 282, in reset
    self._scene._finalize(self.physics_sim_view)
  File "/home/nicky/.local/share/ov/pkg/isaac_sim-2022.2.1/exts/omni.isaac.core/omni/isaac/core/scenes/scene.py", line 288, in _finalize
    articulated_system.initialize(physics_sim_view)
  File "/home/nicky/.local/share/ov/pkg/isaac_sim-2022.2.1/QNAI/isaac_ws/utils/unitree.py", line 340, in initialize
    super().initialize(physics_sim_view=physics_sim_view)
  File "/home/nicky/.local/share/ov/pkg/isaac_sim-2022.2.1/exts/omni.isaac.core/omni/isaac/core/articulations/articulation.py", line 163, in initialize
    self._articulation_view.initialize(physics_sim_view=physics_sim_view)
  File "/home/nicky/.local/share/ov/pkg/isaac_sim-2022.2.1/exts/omni.isaac.core/omni/isaac/core/articulations/articulation_view.py", line 224, in initialize
    self._default_joints_state.positions = default_actions.joint_positions
AttributeError: 'NoneType' object has no attribute 'joint_positions'
Exception ignored in: <function _make_registry.<locals>._Registry.__del__ at 0x7f76cbf6c0e0>
Traceback (most recent call last):
  File "/home/nicky/.local/share/ov/pkg/isaac_sim-2022.2.1/kit/extscore/omni.kit.viewport.registry/omni/kit/viewport/registry/registry.py", line 103, in __del__
  File "/home/nicky/.local/share/ov/pkg/isaac_sim-2022.2.1/kit/extscore/omni.kit.viewport.registry/omni/kit/viewport/registry/registry.py", line 98, in destroy
TypeError: 'NoneType' object is not callable
Exception ignored in: <function _make_registry.<locals>._Registry.__del__ at 0x7f76cbf6c0e0>
Traceback (most recent call last):
  File "/home/nicky/.local/share/ov/pkg/isaac_sim-2022.2.1/kit/extscore/omni.kit.viewport.registry/omni/kit/viewport/registry/registry.py", line 103, in __del__
  File "/home/nicky/.local/share/ov/pkg/isaac_sim-2022.2.1/kit/extscore/omni.kit.viewport.registry/omni/kit/viewport/registry/registry.py", line 98, in destroy
TypeError: 'NoneType' object is not callable
Exception ignored in: <function SettingChangeSubscription.__del__ at 0x7f77451f2290>
Traceback (most recent call last):
  File "/home/nicky/.local/share/ov/pkg/isaac_sim-2022.2.1/kit/kernel/py/omni/kit/app/_impl/__init__.py", line 114, in __del__
AttributeError: 'NoneType' object has no attribute 'get_settings'
Exception ignored in: <function RegisteredActions.__del__ at 0x7f75cc3fc3b0>
Traceback (most recent call last):
  File "/home/nicky/.local/share/ov/pkg/isaac_sim-2022.2.1/extscache/omni.kit.viewport.menubar.lighting-104.0.9/omni/kit/viewport/menubar/lighting/actions.py", line 347, in __del__
  File "/home/nicky/.local/share/ov/pkg/isaac_sim-2022.2.1/extscache/omni.kit.viewport.menubar.lighting-104.0.9/omni/kit/viewport/menubar/lighting/actions.py", line 352, in destroy
TypeError: 'NoneType' object is not callable
```